### PR TITLE
Tutorial 9: Web applications - init

### DIFF
--- a/tutorials/09_webapp.hs
+++ b/tutorials/09_webapp.hs
@@ -1,0 +1,63 @@
+# Web application in Haskell
+
+Haskell is possible to use web applications and it has some advantages when compared to others like PHP, Python or Java.
+
+## Network communication
+
+### Sockets
+
+### Server
+
+### Client
+
+### Specialized libraries
+
+## Web Frameworks overview
+
+As with other languages, you usually don't want to build web application from scratch which would bind ports, listen and parse requests and compose responses. For better abstraction you want to use a web framework.
+
+### Snap
+
+[Snap](http://snapframework.com) is a simple web development framework for unix systems, written in the Haskell programming language. It consists of:
+
+* A fast HTTP server library
+* A sensible and clean monad for web programming
+* An HTML-based templating system for generating pages (heist)
+
+Snap also has very nice philosophy in form of an optional system for building reusable pieces web functionality called “snaplets”. Snaplets make it easy to share and reuse common code across multiple web apps. The default snaplets let you get a full-featured web application up and running in no time.
+
+More including examples is in the [documentation](http://snapframework.com/docs).
+
+### Yesod
+
+[Yesod](https://www.yesodweb.com) is a Haskell web framework for productive development of type-safe, RESTful, high performance web applications. It build on Haskell features such as compile-time errors (instead of runtime), seamlessly asynchronous computation, scalability, good performance and light-weight syntax.
+
+Another advantage of Yesod is comprehensive documentation including:
+
+* [quick start guide](https://www.yesodweb.com/page/quickstart),
+* [book](https://www.yesodweb.com/book) (O'Reilly),
+* [screencasts](https://www.yesodweb.com/page/screencasts),
+* and [cookbook](https://github.com/yesodweb/yesod-cookbook).
+
+If that is not enough you can ask the [community](https://www.yesodweb.com/page/community).
+
+### Scotty
+
+[Scotty](https://github.com/scotty-web/scotty) is another Haskell web framework inspired by Ruby's [Sinatra](http://sinatrarb.com), using [WAI](https://hackage.haskell.org/package/wai) and [Warp](https://hackage.haskell.org/package/warp) (a fast, light-weight web server for WAI applications). You can write your own application just with WAI (Web Application Interface), but Scotty provides you better abstractions from low-level communication. Sadly there is not so much documentation about Scotty, everything is just on [GitHub](https://github.com/scotty-web/scotty). Scotty uses [Blaze HTML](https://hackage.haskell.org/package/blaze-html) for HTML "templates".
+
+#### Hastache templates
+
+## Example app: Simple blog with Scotty
+
+//TODO: GitHub link to application and interesting parts commented here
+
+## Task assignment
+
+The homework to complete a simple web app is in repository [MI-AFP/hw09](https://github.com/MI-AFP/hw09).
+
+## Further reading
+
+* [Haskell web frameworks](https://wiki.haskell.org/Web/Frameworks)
+* [The JavaScript problem](https://wiki.haskell.org/The_JavaScript_Problem)
+* [Reddit: Web development using Haskell](https://www.reddit.com/r/haskell/comments/2wfap0/web_development_using_haskell/)
+* [Is Haskell a Good Choice for Web Applications?](http://jekor.com/article/is-haskell-a-good-choice-for-web-applications)

--- a/tutorials/09_webapp.md
+++ b/tutorials/09_webapp.md
@@ -1,6 +1,6 @@
 # Web application in Haskell
 
-Haskell can be (of course) used for network communication and also for building various web applications. In this tutorial, we are going to look at basics of network communication in Haskell, some specialized libraries making it simpler, and then at web frameworks. 
+Haskell can be (of course) used for network communication and also for building various web applications. In this tutorial, we are going to look at basics of network communication in Haskell, some specialized libraries making it simpler, and then at web frameworks.
 
 ## Network communication
 
@@ -8,7 +8,7 @@ On the way to web applications, it is good to know how you can work with network
 
 ### Sockets
 
-The most low-level solutions for you are working directly with sockets via [Network.Socket](https://hackage.haskell.org/package/network/docs/Network-Socket.html) module. With that, you have full control over the communication. Essentially the entire C socket API is exposed through this module, so if you are familiar with sockets from C, then it will be easy for you in Haskell: `bind`, `listen`, `receive`, `send`, `getAddrInfo`, etc.
+The most low-level solutions work directly with sockets via [Network.Socket](https://hackage.haskell.org/package/network/docs/Network-Socket.html) module. With that, you have a full control over the communication. Essentially the entire C socket API is exposed through this module, so if you are familiar with sockets from C, then it will be easy for you in Haskell: `bind`, `listen`, `receive`, `send`, `getAddrInfo`, etc.
 
 ### Server-client demo with sockets
 
@@ -84,11 +84,13 @@ main = withSocketsDo $ do
         C.putStrLn msg
 ```
 
+A you can see, most of the work happens in `do` of `IO` and it highly resembles classic imperative programming. Indeed, networking and also most of UI is inherently not a show room of beautiful Haskell code, but it gets the job done ;-).
+
 ### Specialized libraries
 
-Naturally, there are many specialized libraries that provide a simpler interface for network communication than are plain sockets when you want to work with some specific protocol (POP3, SMTP, SSH, or HTTP). Some are listed [here](https://wiki.haskell.org/Applications_and_libraries/Network) but you can find more on [Hackage](https://hackage.haskell.org).
+Naturally, there are many specialized libraries that provide a higher-level interface for network communication than plain sockets when you want to work with some specific protocol (POP3, SMTP, SSH, or HTTP). Some are listed [here](https://wiki.haskell.org/Applications_and_libraries/Network) but you can find more on [Hackage](https://hackage.haskell.org).
 
-The need of REST API client is something very common. For writing a simple one, you may use [wreq](https://hackage.haskell.org/package/wreq) package. It provides simple but powerful lens-based API, is capable of simple but powerful lens-based API, and supports often used techniques like OAuth, decompression, file upload, etc.
+The need of REST API client is something very common. For writing a simple one, you may use [wreq](https://hackage.haskell.org/package/wreq) package. It provides simple but powerful lens-based API and it supports often-used techniques like OAuth, decompression, file upload, etc.
 
 ```haskell
 -- GitHub API: list public repositories of user
@@ -120,9 +122,9 @@ main = do
 
 ## Web Frameworks overview
 
-As with other languages, you usually don't want to build a web application from scratch which would bind ports, listen and parse requests and compose responses. For better abstraction, you might want to use a web framework.
+As with other languages, you usually don't want to build a web application from the scratch which would bind ports, listen and parse requests and compose responses. For a higher abstraction, you might want to use a web framework.
 
-There are several frameworks in Haskell (see [here](https://wiki.haskell.org/Web/Frameworks)) and here is our list of well-known:
+There are several frameworks in Haskell (see [here](https://wiki.haskell.org/Web/Frameworks)) and here is our list of the most used ones:
 
 - [Happstack](http://happstack.com)
 - [Scotty](https://github.com/scotty-web/scotty)
@@ -131,7 +133,11 @@ There are several frameworks in Haskell (see [here](https://wiki.haskell.org/Web
 - [Spock](https://www.spock.li)
 - [Yesod](https://www.yesodweb.com)
 
-We are going to show briefly Snap and Yesod because they are used quite often and then we will show more with our favorite Scotty. Next time, we will look at different one to build quickly REST API for our front-end app(s).
+As you can see, there is quite an above-average offer of them. They mostly differ at the level of abstraction and scope: Scotty being relatively low-abstraction routing and middleware and Yesod being a complete solution including templating and persistence, everything on a high abstraction level. The choice depends on your preference and needs. As always, a higher abstraction means the system does a lot of job for yourself, you write fewer code, which means a higher effectiveness and less bugs. On the other hand, you may face a [leaky abstraction problem](https://blog.codinghorror.com/all-abstractions-are-failed-abstractions/) at some point.
+
+We are going to show briefly Snap and Yesod, because they are used often and then we will go deeper with our favourite versatile Scotty. Next time, we will look at a different one to build quickly a REST API for our front-end app(s).
+
+However, before we dive into the topic, there is one more note, which may excite you. In the first lecture, we explained what a referential transparency is and that it brings certain qualities to code -- ability to reason about, reusability, testability, parallelism "for free". In the case of web frameworks, you can experience reusability coming from reference transparency very clearly: web frameworks are typically built of certain independent, shared components like a web server ([warp](https://hackage.haskell.org/package/warp)) or a web application interface ([wai](https://hackage.haskell.org/package/wai)). These highly-specialised components are developed independently, tested independently and as such, the whole ecosystem exercises an unparalleled separation of concerns and thanks to it, it is easier evolvable, reliable and lively. Moreover, you can use the low-level components independently and integrate them easily in another framework or even an non-web application -- you can e.g. use [templating from Yesod](https://hackage.haskell.org/package/shakespeare) in Scotty, if you like, or its [persistence layer](https://hackage.haskell.org/package/persistent) in a simple CLI application.
 
 ### Snap
 
@@ -168,9 +174,9 @@ main = quickHttpServe site
 
 #### Snaplets
 
-Snap also has a very nice philosophy in form of an optional system for building reusable pieces web functionality called “snaplets”. Snaplets make it easy to share and reuse common code across multiple web apps. The default snaplets let you get a full-featured web application up and running in no time.
+Snap also has a very nice philosophy in form of an optional system for building reusable pieces web functionality called “snaplets”. Snaplets make it easy to share and reuse common code across multiple web apps. The default snaplets let you get a full-featured web application up and running very fast.
 
-If you want to build such application read [this](http://snapframework.com/docs/tutorials/snaplets-tutorial).
+If you want to build such application, read [this](http://snapframework.com/docs/tutorials/snaplets-tutorial).
 
 ### Yesod
 
@@ -185,9 +191,11 @@ Another advantage of Yesod is comprehensive documentation including:
 
 If that is not enough you can ask the [community](https://www.yesodweb.com/page/community).
 
+Yesod is a "Mercedes" of Haskell web frameworks. It means a lot of comfort is prepared for you to enjoy, however it also means that people needing an agile small car for Italian crooked streets may experience troubles ;-).
+
 #### "Hello World"
 
-From the following example, you can see that Yesod uses a lot of *Template Haskell* which makes it a little bit hard to get at the beginning. 
+From the following example, you can see that Yesod uses a lot of *Template Haskell* which makes it a little bit hard to get at the beginning, but it enchants you with a lot of pleasant magic. And yes, every magic has some costs ;-) (see the previous lecture).
 
 ```haskell
 {-# LANGUAGE OverloadedStrings     #-}
@@ -209,13 +217,11 @@ getHomeR = defaultLayout [whamlet|Hello World!|]
 
 main :: IO ()
 main = warp 3000 HelloWorld
-``` 
-
-As you can see from the last line, Yesod uses web server [warp](https://hackage.haskell.org/package/warp).
+```
 
 ### Scotty
 
-[Scotty](https://github.com/scotty-web/scotty) is another Haskell web framework inspired by Ruby's [Sinatra](http://sinatrarb.com), using [WAI](https://hackage.haskell.org/package/wai) and [Warp](https://hackage.haskell.org/package/warp) (a fast, light-weight web server for WAI applications). You can write your own application just with WAI (Web Application Interface), but Scotty provides you better abstractions from low-level communication. Sadly there is not so much documentation about Scotty, everything is just on [GitHub](https://github.com/scotty-web/scotty). Scotty uses [Blaze HTML](https://hackage.haskell.org/package/blaze-html) for HTML "templates".
+[Scotty](https://github.com/scotty-web/scotty) is another Haskell web framework inspired by Ruby's [Sinatra](http://sinatrarb.com), using [WAI](https://hackage.haskell.org/package/wai) and [Warp](https://hackage.haskell.org/package/warp) (a fast, light-weight web server for WAI applications). You can write your own application just with WAI (Web Application Interface), but Scotty provides you with abstractions from a low-level communication. Sadly, there is not so much documentation about Scotty, everything is just on [GitHub](https://github.com/scotty-web/scotty). Scotty uses primarily [Blaze HTML](https://hackage.haskell.org/package/blaze-html) for HTML "templates", however, as we explained, you may also integrate it with any templating library you like.
 
 #### "Hello World"
 
@@ -232,7 +238,7 @@ Surprisingly easy, right?!
 
 #### Blaze templates
 
-One of the well-known and widely used solution for HTML templates is [Blaze HTML](https://hackage.haskell.org/package/blaze-html). It is a blazingly fast HTML combinator library for the Haskell programming language. A huge advantage of Blaze is that you write HTML via HTML-like lightweight DSL in Haskell with the great type system. Blaze and Haskell won't allow you to do non-sense HTML.
+One of the well-known and widely used solution for HTML templates is [Blaze HTML](https://hackage.haskell.org/package/blaze-html). It is "a blazingly fast HTML combinator library for the Haskell programming language". A huge advantage of Blaze is that you write HTML via HTML-like lightweight DSL in Haskell with the great type system. Blaze and Haskell won't allow you to make a non-sense HTML, although it does not check a full conformity, of course.
 
 ```haskell
 {-# LANGUAGE OverloadedStrings #-}
@@ -263,33 +269,33 @@ main :: IO ()
 main = putStr . renderHtml $ somePage (Just "Marek")
 ```
 
-Interesting tool, that you might find useful, is [blaze-from-html](https://hackage.haskell.org/package/blaze-from-html).
+An interesting tool, that you might find useful, is [blaze-from-html](https://hackage.haskell.org/package/blaze-from-html).
 
-You might ask "What about styles?" or "What if want to have some JavaScript there?". For styles, there is [clay](https://hackage.haskell.org/package/clay) - a CSS preprocessor like LESS and Sass, but implemented as an embedded domain specific language (EDSL) in Haskell. Similarly to Blaze, you write CSS but in Haskell. For JavaScript, stay tuned for next tutorial.
+You might ask "What about styles?" or "What if want to have some JavaScript there?". For styles, there is [clay](https://hackage.haskell.org/package/clay) - a CSS preprocessor like LESS and Sass, but implemented as an embedded domain specific language (EDSL) in Haskell. Similarly to Blaze, you write CSS in Haskell. For JavaScript, stay tuned for the next tutorial ;-).
 
 #### Hastache templates
 
-If you are already familiar with some web development, you've probably heard about [{{ mustache }}](http://mustache.github.io) templates. In Haskell, we have Haskell implementation of Mustache templates called [hastache](https://hackage.haskell.org/package/hastache).
+If you are already familiar with some web development, you've probably heard about the popular [{{ mustache }}](http://mustache.github.io) templates. In Haskell, we have Haskell implementation of Mustache templates called [hastache](https://hackage.haskell.org/package/hastache).
 
 ```haskell
-import Text.Hastache 
-import Text.Hastache.Context 
-import qualified Data.Text.Lazy.IO as TL 
+import Text.Hastache
+import Text.Hastache.Context
+import qualified Data.Text.Lazy.IO as TL
 
 main = hastacheStr defaultConfig (encodeStr template) (mkStrContext context)
     >>= TL.putStrLn
 
-template = "Hello, {{#reverse}}world{{/reverse}}! We know you, {{name}}!" 
+template = "Hello, {{#reverse}}world{{/reverse}}! We know you, {{name}}!"
 
 context "reverse" = MuLambda (reverse . decodeStr)
 context "name" = MuVariable "Haskell"
 ```
 
-A useful source of information what can you do in this template are [examples](https://github.com/lymar/hastache/tree/master/examples).
+A useful source of information what can you do with Hastache are [examples](https://github.com/lymar/hastache/tree/master/examples).
 
 #### Databases
 
-First, you can work with database with low-level approach where you have own *CREATE* script and then other SQL (or other) parametric scripts in the code. For that, you can usually use module `Database.X` where `X` is type of datase:
+Again, several abstraction levels are available. First, you can employ a low-level approach where you incorporate SQL in the code. For that, you can usually use module `Database.X` where `X` is type of datase:
 
 - [Database.SQLite](http://hackage.haskell.org/package/sqlite-simple)
 - [Database.MySQL](http://hackage.haskell.org/package/mysql)
@@ -298,7 +304,12 @@ First, you can work with database with low-level approach where you have own *CR
 - [Database.Redis](http://hackage.haskell.org/package/redis)
 - etc.
 
-For higher level, you can then use [Haskell Database Connectivity (HDBC)](http://hackage.haskell.org/package/HDBC) for SQL databases. A good introduction to HDBC is in [Chapter 21 - Using Databases](http://book.realworldhaskell.org/read/using-databases.html) of the [Real World Haskell](http://book.realworldhaskell.org/) book.
+A slightly better services are provided by mid-level libraries:
+
+- [Database.MySQL.Simple](https://hackage.haskell.org/package/mysql-simple)
+- [Database.PostgreSQL.Simple](https://hackage.haskell.org/package/postgresql-simple)
+
+Going higher with the abstraction, you can then use [Haskell Database Connectivity (HDBC)](http://hackage.haskell.org/package/HDBC) for SQL databases. A good introduction to HDBC is in [Chapter 21 - Using Databases](http://book.realworldhaskell.org/read/using-databases.html) of the [Real World Haskell](http://book.realworldhaskell.org/) book.
 
 ```sql
 CREATE TABLE test(id INTEGER PRIMARY KEY, str TEXT);\
@@ -328,7 +339,7 @@ main = do
 
 #### Persistence with Persistent
 
-Again, there are several prepared libraries for working with persistence (DB) - take a look [here](https://wiki.haskell.org/Web/Databases_and_Persistence) or search the [Hackage](https://hackage.haskell.org). One of the most used is [persistent](https://hackage.haskell.org/package/persistent) also with various [extensions](https://hackage.haskell.org/packages/search?terms=persistent). There is nice documentation of this package in Yesod [book](https://www.yesodweb.com/book/persistent), but you can use it with any framework or even without any framework - just whenever you need to persist some data in a database.
+Now skyrocketing the abstraction to the heights of Template Haskell, we get to [persistent](https://hackage.haskell.org/package/persistent) that comes also with various [extensions](https://hackage.haskell.org/packages/search?terms=persistent). There is a nice documentation of this package in the Yesod [book](https://www.yesodweb.com/book/persistent), but, as we already explained, you can use it with any framework or even without any framework — just whenever you need to persist some data in a database.
 
 ```haskell
 {-# LANGUAGE EmptyDataDecls             #-}
@@ -376,7 +387,9 @@ main = runSqlite ":memory:" $ do
     deleteWhere [BlogPostAuthorId ==. johnId]
 ```
 
-Persistent uses *Template Haskell* for a declaration of a persistent model.
+As you noticed, Persistent uses *Template Haskell* for a declaration of a persistent model.
+
+For other possibilities of persistence libraries, take a look [here](https://wiki.haskell.org/Web/Databases_and_Persistence) or search the [Hackage](https://hackage.haskell.org).
 
 ## WAI and testing web apps
 
@@ -408,7 +421,7 @@ main = do
 
 ### HSpec & WAI
 
-Web applications in Haskell can be tested via WAI. All applications that conform with WAI can be tested in the same way like a black box - send a request and check the response. In our favorite [Hspec](https://hspec.github.io), there is an extension [hspec-wai](https://github.com/hspec/hspec-wai) that allows you to test web applications in very easy and readable way as we are used to with hspec.
+Web applications in Haskell can be tested via WAI. All applications that conform with WAI can be tested in the same way like a black box - send a request and check the response. In our favourite [Hspec](https://hspec.github.io), there is an extension [hspec-wai](https://github.com/hspec/hspec-wai) that allows you to test web applications in a very easy and readable way, as we are used to with hspec.
 
 ```haskell
 {-# LANGUAGE OverloadedStrings, QuasiQuotes #-}
@@ -458,15 +471,25 @@ This is just a simple (but often sufficient) example. Of course, you can test mu
 - https://begriffs.com/posts/2014-10-19-warp-server-controller-test.html
 - https://www.spock.li/tutorials/testing
 
-## Example apps: 
+## Example apps:
 
-There are few examples of simple and complex web apps:
+Here are a few examples of simple and more complex web apps:
 
 * [dbushenko/scotty-blog](https://github.com/dbushenko/scotty-blog)
 * [DataStewardshipWizard/ds-wizard](https://github.com/DataStewardshipWizard/ds-wizard/tree/master/DSServer)
 * [DataStewardshipWizard/dsw-server](https://github.com/DataStewardshipWizard/dsw-server)
 
-Next time, we will deal a bit with frontend technologies for Haskell, functional reactive programming and [The JavaScript problem](https://wiki.haskell.org/The_JavaScript_Problem). So you will also see how to develop server-side and client-side separately and connect them thru some (REST) API.
+
+## Continuation-style web development
+
+We would also like to raise your attention to an interesting approach to web development based on the [continuation](https://wiki.haskell.org/Continuation). A continuation is "something" that enables you to save the state of computation, suspend it (do something else) and later resume it. This "something" may be a first-class language feature (such as in Scheme), or a library feature -- in Haskell, surprisingly, we have a continuation monad ;-).
+
+A need for continuation occurs typically in web development (and generally in UI development) when you want a modal dialogue. Today, most of the dialogues are handled on client-side, however if you need to do a modal dialogue on server-side, it is hard -- HTTP behaves like a programming language, which does not have subroutines, only GOTOs (URLSs are the 'line numbers'). Continuation can provide the missing abstraction here, which is embodied in the [MFlow](http://mflowdemo.herokuapp.com) library. Sadly, the project seems abandoned for several years.
+
+At the same time, the continuation-style web server programming is typically the first choice in the Smalltalk (OOP) world -- [Seaside](http://seaside.st/) is purely continuation-based, and as such it gives a "desktop programming" experience for the web development resulting in no need of dealing with routing and URLs. As for the FP world, continuation-style web programming is surprisingly not used much in practice, but there are solutions such as the [Racket web server](https://docs.racket-lang.org/web-server/index.html) or [cl-weblocks](https://www.cliki.net/cl-weblocks) in Common Lisp.
+
+
+The next time, we will deal a bit with frontend technologies for Haskell, functional reactive programming and [The JavaScript problem](https://wiki.haskell.org/The_JavaScript_Problem). So you will also see how to develop server-side and client-side separately and connect them through a (REST) API.
 
 ## Task assignment
 

--- a/tutorials/09_webapp.md
+++ b/tutorials/09_webapp.md
@@ -458,11 +458,13 @@ This is just a simple (but often sufficient) example. Of course, you can test mu
 - https://begriffs.com/posts/2014-10-19-warp-server-controller-test.html
 - https://www.spock.li/tutorials/testing
 
-## Example app: a simple blog with Scotty
+## Example apps: 
 
-Now let's put it all together and look at the development of simple blog app with a database, authentication, and simple templates. 
+There are few examples of simple and complex web apps:
 
-* [MI-AFP/scotty-blog](https://github.com/MI-AFP/scotty-blog)
+* [dbushenko/scotty-blog](https://github.com/dbushenko/scotty-blog)
+* [DataStewardshipWizard/ds-wizard](https://github.com/DataStewardshipWizard/ds-wizard/tree/master/DSServer)
+* [DataStewardshipWizard/dsw-server](https://github.com/DataStewardshipWizard/dsw-server)
 
 Next time, we will deal a bit with frontend technologies for Haskell, functional reactive programming and [The JavaScript problem](https://wiki.haskell.org/The_JavaScript_Problem). So you will also see how to develop server-side and client-side separately and connect them thru some (REST) API.
 

--- a/tutorials/09_webapp.md
+++ b/tutorials/09_webapp.md
@@ -122,7 +122,16 @@ main = do
 
 As with other languages, you usually don't want to build web application from scratch which would bind ports, listen and parse requests and compose responses. For better abstraction you want to use a web framework.
 
-There are several frameworks in Haskell (see [here](https://wiki.haskell.org/Web/Frameworks)). We are going to show briefly Snap and Yesod because they are used quite often and then we will show more with our favorite Scotty. 
+There are several frameworks in Haskell (see [here](https://wiki.haskell.org/Web/Frameworks)) and here is our list of well-known:
+
+- [Happstack](http://happstack.com)
+- [Scotty](https://github.com/scotty-web/scotty)
+- [Servant](https://haskell-servant.github.io)
+- [Snap](http://snapframework.com)
+- [Spock](https://www.spock.li)
+- [Yesod](https://www.yesodweb.com)
+
+We are going to show briefly Snap and Yesod because they are used quite often and then we will show more with our favorite Scotty. Next time, we will look at different one to build quickly REST API for our front-end app(s).
 
 ### Snap
 
@@ -276,6 +285,45 @@ context "name" = MuVariable "Haskell"
 
 Useful source of information what can you do in this template are [examples](https://github.com/lymar/hastache/tree/master/examples).
 
+#### Databases
+
+First, you can work with database with low-level approach where you have own *CREATE* script and then other SQL (or other) parametric scripts in the code. For that, you can usually use module `Database.X` where `X` is type of datase:
+
+- [Database.SQLite](http://hackage.haskell.org/package/sqlite-simple)
+- [Database.MySQL](http://hackage.haskell.org/package/mysql)
+- [Database.PostgreSQL](http://hackage.haskell.org/package/PostgreSQL)
+- [Database.MongoDB](http://hackage.haskell.org/package/mongoDB)
+- [Database.Redis](http://hackage.haskell.org/package/redis)
+- etc.
+
+For higher level, you can then use [Haskell Database Connectivity (HDBC)](http://hackage.haskell.org/package/HDBC) for SQL databases. A good introduction into HDBC is in [Chapter 21 - Using Databases](http://book.realworldhaskell.org/read/using-databases.html) of the [Real World Haskell](http://book.realworldhaskell.org/) book.
+
+```sql
+CREATE TABLE test(id INTEGER PRIMARY KEY, str TEXT);\
+INSERT INTO test(str) VALUES ('test string 1');
+INSERT INTO test(str) VALUES ('test string 2');
+```
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+import Control.Applicative
+import Database.SQLite.Simple
+import Database.SQLite.Simple.FromRow
+
+data TestField = TestField Int String deriving (Show)
+
+instance FromRow TestField where
+  fromRow = TestField <$> field <*> field
+
+main :: IO ()
+main = do
+  conn <- open "test.db"
+  execute conn "INSERT INTO test (str) VALUES (?)"
+    (Only ("test string 2" :: String))
+  r <- query_ conn "SELECT * from test" :: IO [TestField]
+  mapM_ print r
+```
+
 #### Persistence with Persistent
 
 Again, there are several prepared libraries for working with persistence (DB) - take a look [here](https://wiki.haskell.org/Web/Databases_and_Persistence) or search the [Hackage](https://hackage.haskell.org). One of the most used is [persistent](https://hackage.haskell.org/package/persistent) also with various [extensions](https://hackage.haskell.org/packages/search?terms=persistent). There is nice documentation of this package in Yesod [book](https://www.yesodweb.com/book/persistent), but you can use it with any framework or even without any framework - just whenever you need to persist some data in database.
@@ -383,7 +431,11 @@ spec = with app $
 
 ## Example app: Simple blog with Scotty
 
-//TODO: GitHub link to application and interesting parts commented here
+Now let's put it all together and look at the development of simple blog app with database, authentication, and simple templates. 
+
+* [MI-AFP/scotty-blog](https://github.com/MI-AFP/scotty-blog)
+
+Next time, we will deal a bit with frontend technologies for Haskell, functional reactive programming and [The JavaScript problem](https://wiki.haskell.org/The_JavaScript_Problem). So you will also see how to develop server-side and client-side separately and connect them thru some (REST) API.
 
 ## Task assignment
 
@@ -395,6 +447,6 @@ The homework to complete a simple web app is in repository [MI-AFP/hw09](https:/
 * [adit.io - Making A Website With Haskell](http://adit.io/posts/2013-04-15-making-a-website-with-haskell.html)
 * [24 Days of Hackage: blaze-html](https://ocharles.org.uk/blog/posts/2012-12-22-24-days-of-hackage-blaze.html)
 * [Haskell web frameworks](https://wiki.haskell.org/Web/Frameworks)
-* [The JavaScript problem](https://wiki.haskell.org/The_JavaScript_Problem)
+* [Reddit: What Haskell web framework do you use and why? ](https://www.reddit.com/r/haskell/comments/332s1k/what_haskell_web_framework_do_you_use_and_why/)
 * [Reddit: Web development using Haskell](https://www.reddit.com/r/haskell/comments/2wfap0/web_development_using_haskell/)
 * [Is Haskell a Good Choice for Web Applications?](http://jekor.com/article/is-haskell-a-good-choice-for-web-applications)

--- a/tutorials/09_webapp.md
+++ b/tutorials/09_webapp.md
@@ -202,6 +202,8 @@ main :: IO ()
 main = warp 3000 HelloWorld
 ``` 
 
+As you can see from the last line, Yesod uses web server [warp](https://hackage.haskell.org/package/warp).
+
 ### Scotty
 
 [Scotty](https://github.com/scotty-web/scotty) is another Haskell web framework inspired by Ruby's [Sinatra](http://sinatrarb.com), using [WAI](https://hackage.haskell.org/package/wai) and [Warp](https://hackage.haskell.org/package/warp) (a fast, light-weight web server for WAI applications). You can write your own application just with WAI (Web Application Interface), but Scotty provides you better abstractions from low-level communication. Sadly there is not so much documentation about Scotty, everything is just on [GitHub](https://github.com/scotty-web/scotty). Scotty uses [Blaze HTML](https://hackage.haskell.org/package/blaze-html) for HTML "templates".
@@ -325,6 +327,59 @@ main = runSqlite ":memory:" $ do
 ```
 
 Persistent uses *Template Haskell* for declaration of persistent model.
+
+## WAI and testing wep apps
+
+There must be some interface between a web application and the web server where the application is running. You may have heard about something like [CGI](https://en.wikipedia.org/wiki/Common_Gateway_Interface), [FastCGI](https://en.wikipedia.org/wiki/FastCGI), [WSGI](https://cs.wikipedia.org/wiki/Web_Server_Gateway_Interface), or similar. As is [WSGI](https://cs.wikipedia.org/wiki/Web_Server_Gateway_Interface) for Python web applications, we have [Web Application Interface (WAI)](https://www.stackage.org/package/wai) in Haskell.
+
+### Web app with plain WAI
+
+It is possible to write simple web application with just WAI and without any additional web framework.
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+import Network.Wai
+import Network.HTTP.Types
+import Network.Wai.Handler.Warp (run)
+
+app :: Application
+app _ respond = do
+    putStrLn "I've done some IO here"
+    respond $ responseLBS
+        status200
+        [("Content-Type", "text/plain")]
+        "Hello, Web!"
+
+main :: IO ()
+main = do
+    putStrLn $ "http://localhost:8080/"
+    run 8080 app
+```
+
+### HSpec & WAI
+
+https://github.com/hspec/hspec-wai
+https://begriffs.com/posts/2014-10-19-warp-server-controller-test.html
+
+```haskell
+app :: IO Application
+app = S.scottyApp $ do
+  S.get "/" $ do
+    S.text "hello"
+
+spec :: Spec
+spec = with app $
+  describe "GET /" $ do
+    it "responds with 200" $
+      get "/" `shouldRespondWith` 200
+
+    it "responds with 'hello'" $
+      get "/" `shouldRespondWith` "hello"
+
+    it "responds with 200 / 'hello'" $
+      get "/" `shouldRespondWith` "hello" {matchStatus = 200}
+```
+
 
 ## Example app: Simple blog with Scotty
 

--- a/tutorials/09_webapp.md
+++ b/tutorials/09_webapp.md
@@ -6,15 +6,15 @@ Haskell can be (of course) used for network communication and also for building 
 
 ### Sockets
 
-### Server
-
-### Client
+### Server-client demo
 
 ### Specialized libraries
 
 ## Web Frameworks overview
 
 As with other languages, you usually don't want to build web application from scratch which would bind ports, listen and parse requests and compose responses. For better abstraction you want to use a web framework.
+
+There are several frameworks in Haskell (see [here](https://wiki.haskell.org/Web/Frameworks)). We are going to show briefly Snap and Yesod because they are used quite often and then we will show more with our favorite Scotty. 
 
 ### Snap
 
@@ -24,9 +24,36 @@ As with other languages, you usually don't want to build web application from sc
 * A sensible and clean monad for web programming
 * An HTML-based templating system for generating pages (heist)
 
+More examples are in the [documentation](http://snapframework.com/docs).
+
+#### "Hello World"
+
+```haskell
+import Snap
+
+site :: Snap ()
+site =
+    ifTop (writeBS "hello world") <|>
+    route [ ("foo", writeBS "bar")
+          , ("echo/:echoparam", echoHandler)
+          ] <|>
+    dir "static" (serveDirectory ".")
+
+echoHandler :: Snap ()
+echoHandler = do
+    param <- getParam "echoparam"
+    maybe (writeBS "must specify echo/param in URL")
+          writeBS param
+
+main :: IO ()
+main = quickHttpServe site
+```
+
+#### Snaplets
+
 Snap also has very nice philosophy in form of an optional system for building reusable pieces web functionality called “snaplets”. Snaplets make it easy to share and reuse common code across multiple web apps. The default snaplets let you get a full-featured web application up and running in no time.
 
-More including examples is in the [documentation](http://snapframework.com/docs).
+If you want to build such application read [this](http://snapframework.com/docs/tutorials/snaplets-tutorial).
 
 ### Yesod
 
@@ -41,11 +68,56 @@ Another advantage of Yesod is comprehensive documentation including:
 
 If that is not enough you can ask the [community](https://www.yesodweb.com/page/community).
 
+#### "Hello World"
+
+From the following example, you can see that Yesod uses a lot of *Template Haskell* which makes it little bit hard to get at the beginning. 
+
+```haskell
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeFamilies          #-}
+import Yesod
+
+data HelloWorld = HelloWorld
+
+mkYesod "HelloWorld" [parseRoutes|
+/ HomeR GET
+|]
+
+instance Yesod HelloWorld
+
+getHomeR :: Handler Html
+getHomeR = defaultLayout [whamlet|Hello World!|]
+
+main :: IO ()
+main = warp 3000 HelloWorld
+``` 
+
 ### Scotty
 
 [Scotty](https://github.com/scotty-web/scotty) is another Haskell web framework inspired by Ruby's [Sinatra](http://sinatrarb.com), using [WAI](https://hackage.haskell.org/package/wai) and [Warp](https://hackage.haskell.org/package/warp) (a fast, light-weight web server for WAI applications). You can write your own application just with WAI (Web Application Interface), but Scotty provides you better abstractions from low-level communication. Sadly there is not so much documentation about Scotty, everything is just on [GitHub](https://github.com/scotty-web/scotty). Scotty uses [Blaze HTML](https://hackage.haskell.org/package/blaze-html) for HTML "templates".
 
+#### "Hello World"
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+import Web.Scotty
+
+main = scotty 3000 $ do
+  get "/" $ do
+    html "Hello World!"
+```
+
+Surprisingly easy, right?!
+
+#### Blaze templates
+
 #### Hastache templates
+
+#### Persistence with Persistent
+
+https://wiki.haskell.org/Web/Databases_and_Persistence
 
 ## Example app: Simple blog with Scotty
 

--- a/tutorials/09_webapp.md
+++ b/tutorials/09_webapp.md
@@ -1,6 +1,6 @@
 # Web application in Haskell
 
-Haskell is possible to use web applications and it has some advantages when compared to others like PHP, Python or Java.
+Haskell can be (of course) used for network communication and also for building various web applications. In this tutorial, we are going to look at basics of network communication in Haskell, some specialized libraries making it simplet, and then at web frameworks. 
 
 ## Network communication
 

--- a/tutorials/09_webapp.md
+++ b/tutorials/09_webapp.md
@@ -1,18 +1,18 @@
 # Web application in Haskell
 
-Haskell can be (of course) used for network communication and also for building various web applications. In this tutorial, we are going to look at basics of network communication in Haskell, some specialized libraries making it simplet, and then at web frameworks. 
+Haskell can be (of course) used for network communication and also for building various web applications. In this tutorial, we are going to look at basics of network communication in Haskell, some specialized libraries making it simpler, and then at web frameworks. 
 
 ## Network communication
 
-On they way to web applications, it is good to know how you can work with network communication on lower levels than is some web framework.
+On the way to web applications, it is good to know how you can work with network communication on lower levels than is some web framework.
 
 ### Sockets
 
-The most low level solutions for you is working directly with sockets via [Network.Socket](https://hackage.haskell.org/package/network/docs/Network-Socket.html) module. With that, you have full control over the communication. Essentially the entire C socket API is exposed through this module, so if you are familiar with sockets from C, then it will be easy for you in Haskell: `bind`, `listen`, `receive`, `send`, `getAddrInfo`, etc.
+The most low-level solutions for you are working directly with sockets via [Network.Socket](https://hackage.haskell.org/package/network/docs/Network-Socket.html) module. With that, you have full control over the communication. Essentially the entire C socket API is exposed through this module, so if you are familiar with sockets from C, then it will be easy for you in Haskell: `bind`, `listen`, `receive`, `send`, `getAddrInfo`, etc.
 
 ### Server-client demo with sockets
 
-There is demo with echo server and client in the [Network.Socket](https://hackage.haskell.org/package/network/docs/Network-Socket.html) documentation. We will show a bit simpler example without forking.
+There is a demo with echo server and client in the [Network.Socket](https://hackage.haskell.org/package/network/docs/Network-Socket.html) documentation. We will show a bit simpler example without forking.
 
 ```haskell
 {-# LANGUAGE OverloadedStrings #-}
@@ -86,9 +86,9 @@ main = withSocketsDo $ do
 
 ### Specialized libraries
 
-Naturally, there are many specialized libraries that provide simpler interface for network communication than are plain sockets when you want to work with some specific protocol (POP3, SMTP, SSH, or HTTP). Some are listed [here](https://wiki.haskell.org/Applications_and_libraries/Network) but you can find more on [Hackage](https://hackage.haskell.org).
+Naturally, there are many specialized libraries that provide a simpler interface for network communication than are plain sockets when you want to work with some specific protocol (POP3, SMTP, SSH, or HTTP). Some are listed [here](https://wiki.haskell.org/Applications_and_libraries/Network) but you can find more on [Hackage](https://hackage.haskell.org).
 
-The need of REST API client is something very common. For writting simple one, you may use [wreq](https://hackage.haskell.org/package/wreq) package. It provides simple but powerful lens-based API, is capable of simple but powerful lens-based API, and supports often used techniques like OAuth, decompression, file upload, etc.
+The need of REST API client is something very common. For writing a simple one, you may use [wreq](https://hackage.haskell.org/package/wreq) package. It provides simple but powerful lens-based API, is capable of simple but powerful lens-based API, and supports often used techniques like OAuth, decompression, file upload, etc.
 
 ```haskell
 -- GitHub API: list public repositories of user
@@ -120,7 +120,7 @@ main = do
 
 ## Web Frameworks overview
 
-As with other languages, you usually don't want to build web application from scratch which would bind ports, listen and parse requests and compose responses. For better abstraction you want to use a web framework.
+As with other languages, you usually don't want to build a web application from scratch which would bind ports, listen and parse requests and compose responses. For better abstraction, you might want to use a web framework.
 
 There are several frameworks in Haskell (see [here](https://wiki.haskell.org/Web/Frameworks)) and here is our list of well-known:
 
@@ -135,7 +135,7 @@ We are going to show briefly Snap and Yesod because they are used quite often an
 
 ### Snap
 
-[Snap](http://snapframework.com) is a simple web development framework for unix systems, written in the Haskell programming language. It consists of:
+[Snap](http://snapframework.com) is a simple web development framework for UNIX systems, written in the Haskell programming language. It consists of:
 
 * A fast HTTP server library
 * A sensible and clean monad for web programming
@@ -168,13 +168,13 @@ main = quickHttpServe site
 
 #### Snaplets
 
-Snap also has very nice philosophy in form of an optional system for building reusable pieces web functionality called “snaplets”. Snaplets make it easy to share and reuse common code across multiple web apps. The default snaplets let you get a full-featured web application up and running in no time.
+Snap also has a very nice philosophy in form of an optional system for building reusable pieces web functionality called “snaplets”. Snaplets make it easy to share and reuse common code across multiple web apps. The default snaplets let you get a full-featured web application up and running in no time.
 
 If you want to build such application read [this](http://snapframework.com/docs/tutorials/snaplets-tutorial).
 
 ### Yesod
 
-[Yesod](https://www.yesodweb.com) is a Haskell web framework for productive development of type-safe, RESTful, high performance web applications. It build on Haskell features such as compile-time errors (instead of runtime), seamlessly asynchronous computation, scalability, good performance and light-weight syntax.
+[Yesod](https://www.yesodweb.com) is a Haskell web framework for productive development of type-safe, RESTful, high performance web applications. It builds on Haskell features such as compile-time errors (instead of runtime), seamlessly asynchronous computation, scalability, good performance and light-weight syntax.
 
 Another advantage of Yesod is comprehensive documentation including:
 
@@ -187,7 +187,7 @@ If that is not enough you can ask the [community](https://www.yesodweb.com/page/
 
 #### "Hello World"
 
-From the following example, you can see that Yesod uses a lot of *Template Haskell* which makes it little bit hard to get at the beginning. 
+From the following example, you can see that Yesod uses a lot of *Template Haskell* which makes it a little bit hard to get at the beginning. 
 
 ```haskell
 {-# LANGUAGE OverloadedStrings     #-}
@@ -232,7 +232,7 @@ Surprisingly easy, right?!
 
 #### Blaze templates
 
-One of the well-known and widely used solution for HTML templates is [Blaze HTML](https://hackage.haskell.org/package/blaze-html). It is a blazingly fast HTML combinator library for the Haskell programming language. Huge advantage of Blaze is that you write HTML via HTML-like lightweight DSL in Haskell with great type system. Blaze and Haskell won't allow you to do non-sense HTML.
+One of the well-known and widely used solution for HTML templates is [Blaze HTML](https://hackage.haskell.org/package/blaze-html). It is a blazingly fast HTML combinator library for the Haskell programming language. A huge advantage of Blaze is that you write HTML via HTML-like lightweight DSL in Haskell with the great type system. Blaze and Haskell won't allow you to do non-sense HTML.
 
 ```haskell
 {-# LANGUAGE OverloadedStrings #-}
@@ -265,6 +265,8 @@ main = putStr . renderHtml $ somePage (Just "Marek")
 
 Interesting tool, that you might find useful, is [blaze-from-html](https://hackage.haskell.org/package/blaze-from-html).
 
+You might ask "What about styles?" or "What if want to have some JavaScript there?". For styles, there is [clay](https://hackage.haskell.org/package/clay) - a CSS preprocessor like LESS and Sass, but implemented as an embedded domain specific language (EDSL) in Haskell. Similarly to Blaze, you write CSS but in Haskell. For JavaScript, stay tuned for next tutorial.
+
 #### Hastache templates
 
 If you are already familiar with some web development, you've probably heard about [{{ mustache }}](http://mustache.github.io) templates. In Haskell, we have Haskell implementation of Mustache templates called [hastache](https://hackage.haskell.org/package/hastache).
@@ -283,7 +285,7 @@ context "reverse" = MuLambda (reverse . decodeStr)
 context "name" = MuVariable "Haskell"
 ```
 
-Useful source of information what can you do in this template are [examples](https://github.com/lymar/hastache/tree/master/examples).
+A useful source of information what can you do in this template are [examples](https://github.com/lymar/hastache/tree/master/examples).
 
 #### Databases
 
@@ -296,7 +298,7 @@ First, you can work with database with low-level approach where you have own *CR
 - [Database.Redis](http://hackage.haskell.org/package/redis)
 - etc.
 
-For higher level, you can then use [Haskell Database Connectivity (HDBC)](http://hackage.haskell.org/package/HDBC) for SQL databases. A good introduction into HDBC is in [Chapter 21 - Using Databases](http://book.realworldhaskell.org/read/using-databases.html) of the [Real World Haskell](http://book.realworldhaskell.org/) book.
+For higher level, you can then use [Haskell Database Connectivity (HDBC)](http://hackage.haskell.org/package/HDBC) for SQL databases. A good introduction to HDBC is in [Chapter 21 - Using Databases](http://book.realworldhaskell.org/read/using-databases.html) of the [Real World Haskell](http://book.realworldhaskell.org/) book.
 
 ```sql
 CREATE TABLE test(id INTEGER PRIMARY KEY, str TEXT);\
@@ -326,7 +328,7 @@ main = do
 
 #### Persistence with Persistent
 
-Again, there are several prepared libraries for working with persistence (DB) - take a look [here](https://wiki.haskell.org/Web/Databases_and_Persistence) or search the [Hackage](https://hackage.haskell.org). One of the most used is [persistent](https://hackage.haskell.org/package/persistent) also with various [extensions](https://hackage.haskell.org/packages/search?terms=persistent). There is nice documentation of this package in Yesod [book](https://www.yesodweb.com/book/persistent), but you can use it with any framework or even without any framework - just whenever you need to persist some data in database.
+Again, there are several prepared libraries for working with persistence (DB) - take a look [here](https://wiki.haskell.org/Web/Databases_and_Persistence) or search the [Hackage](https://hackage.haskell.org). One of the most used is [persistent](https://hackage.haskell.org/package/persistent) also with various [extensions](https://hackage.haskell.org/packages/search?terms=persistent). There is nice documentation of this package in Yesod [book](https://www.yesodweb.com/book/persistent), but you can use it with any framework or even without any framework - just whenever you need to persist some data in a database.
 
 ```haskell
 {-# LANGUAGE EmptyDataDecls             #-}
@@ -374,15 +376,15 @@ main = runSqlite ":memory:" $ do
     deleteWhere [BlogPostAuthorId ==. johnId]
 ```
 
-Persistent uses *Template Haskell* for declaration of persistent model.
+Persistent uses *Template Haskell* for a declaration of a persistent model.
 
-## WAI and testing wep apps
+## WAI and testing web apps
 
 There must be some interface between a web application and the web server where the application is running. You may have heard about something like [CGI](https://en.wikipedia.org/wiki/Common_Gateway_Interface), [FastCGI](https://en.wikipedia.org/wiki/FastCGI), [WSGI](https://cs.wikipedia.org/wiki/Web_Server_Gateway_Interface), or similar. As is [WSGI](https://cs.wikipedia.org/wiki/Web_Server_Gateway_Interface) for Python web applications, we have [Web Application Interface (WAI)](https://www.stackage.org/package/wai) in Haskell.
 
 ### Web app with plain WAI
 
-It is possible to write simple web application with just WAI and without any additional web framework.
+It is possible to write a simple web application with just WAI and without any additional web framework.
 
 ```haskell
 {-# LANGUAGE OverloadedStrings #-}
@@ -406,32 +408,59 @@ main = do
 
 ### HSpec & WAI
 
-https://github.com/hspec/hspec-wai
-https://begriffs.com/posts/2014-10-19-warp-server-controller-test.html
+Web applications in Haskell can be tested via WAI. All applications that conform with WAI can be tested in the same way like a black box - send a request and check the response. In our favorite [Hspec](https://hspec.github.io), there is an extension [hspec-wai](https://github.com/hspec/hspec-wai) that allows you to test web applications in very easy and readable way as we are used to with hspec.
 
 ```haskell
+{-# LANGUAGE OverloadedStrings, QuasiQuotes #-}
+module Main (main) where
+
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
+
+import           Network.Wai (Application)
+import qualified Web.Scotty as S
+import           Data.Aeson (Value(..), object, (.=))
+
+main :: IO ()
+main = hspec spec
+
 app :: IO Application
 app = S.scottyApp $ do
   S.get "/" $ do
     S.text "hello"
 
+  S.get "/some-json" $ do
+    S.json $ object ["foo" .= Number 23, "bar" .= Number 42]
+
 spec :: Spec
-spec = with app $
+spec = with app $ do
   describe "GET /" $ do
-    it "responds with 200" $
+    it "responds with 200" $ do
       get "/" `shouldRespondWith` 200
 
-    it "responds with 'hello'" $
+    it "responds with 'hello'" $ do
       get "/" `shouldRespondWith` "hello"
 
-    it "responds with 200 / 'hello'" $
+    it "responds with 200 / 'hello'" $ do
       get "/" `shouldRespondWith` "hello" {matchStatus = 200}
+
+    it "has 'Content-Type: text/plain; charset=utf-8'" $ do
+      get "/" `shouldRespondWith` 200 {matchHeaders = ["Content-Type" <:> "text/plain; charset=utf-8"]}
+
+  describe "GET /some-json" $ do
+    it "responds with some JSON" $ do
+      get "/some-json" `shouldRespondWith` [json|{foo: 23, bar: 42}|]
 ```
 
+This is just a simple (but often sufficient) example. Of course, you can test much more:
 
-## Example app: Simple blog with Scotty
+- https://begriffs.com/posts/2014-10-19-warp-server-controller-test.html
+- https://www.spock.li/tutorials/testing
 
-Now let's put it all together and look at the development of simple blog app with database, authentication, and simple templates. 
+## Example app: a simple blog with Scotty
+
+Now let's put it all together and look at the development of simple blog app with a database, authentication, and simple templates. 
 
 * [MI-AFP/scotty-blog](https://github.com/MI-AFP/scotty-blog)
 


### PR DESCRIPTION
Ninth tutorial (initial version) for this semester (B172) is ready, please review and add/change something if necessary...

It covers: network communications, web frameworks (mainly Scotty), templates (Blaze, Hastache, Clay), databases (low/mid-level, Persistent), WAI and testing web-apps. An example blog app will be prepared soon. For homework there will be another app to be finished or continue in the blog app.

Use squash merge when ready.