### PR TITLE
Tutorial 12: GHC Extensions and Dependent Types

### DIFF
--- a/tutorials/12_exts-deptypes.md
+++ b/tutorials/12_exts-deptypes.md
@@ -2,6 +2,8 @@
 
 ## GHC Language Extensions
 
+Language extensions are used to enable language features in Haskell that may seem useful in certain cases. They can be used to loosen restrictions in the type system or add completely new language constructs to Haskell. As you already know, they can be enabled using the `{-# LANGUAGE <ext> #-}` pragma or using flags `-X<ext>`. You should always consider using those extensions over normal Haskell, because it may also bring some risks.
+
 ### TypeFamilies
 
 ### RankNTypes
@@ -12,16 +14,63 @@
 
 ### QuasiQuotes
 
+[Quasiquoting](https://wiki.haskell.org/Quasiquotation) allows programmers to use custom, domain-specific syntax to construct fragments of their program. Along with Haskell's existing support for domain specific languages, you are now free to use new syntactic forms for your EDSLs.
+
 ### Template Haskell
 
 ## Dependent and Refinement Types
 
-### LiquidHaskell
+A dependent type is a type whose definition depends on a value. Such types can be for example:
+
+* pair of integers where the second is greater than the first,
+* people with age between 18 and 65,
+* string in email format (matches given regex).
+
+Dependent types add complexity to a type system. Deciding the equality of dependent types in a program may require computations. If arbitrary values are allowed in dependent types, then deciding type equality may involve deciding whether two arbitrary programs produce the same result; hence type checking may become undecidable.
 
 ### Agda
 
+[Agda](http://wiki.portal.chalmers.se/agda/pmwiki.php) is a dependently typed functional programming language originally developed by Ulf Norell at Chalmers University of Technology with implementation described in his PhD thesis. But current version, Agda 2, is completely rewritten previous Agda from 1999.
+
+Visit https://github.com/agda/agda where are some examples as well!
+
 ### Idris
+
+[Idris](https://www.idris-lang.org) is a general-purpose purely functional programming language with dependent types, strict or optional lazy evaluation and features such as a totality checker. Idris is highly affected by Haskell and Agda which is also possible to see in the syntax.
+
+Its features are influenced by Haskell and ML, and include:
+
+* Full dependent types with dependent pattern matching
+* Simple foreign function interface (to C)
+* Compiler-supported interactive editing: the compiler helps you write code using the types
+where clauses, with rule, simple case expressions, pattern matching let and lambda bindings
+* Dependent records with projection and update
+* Interfaces (similar to type classes in Haskell)
+* Type-driven overloading resolution
+* `do` notation and idiom brackets
+* Indentation significant syntax
+* Extensible syntax
+* Cumulative universes
+* Totality checking
+* Hugs style interactive environment
+
+On their website you can find a documentation with [examples](https://www.idris-lang.org/example/) such as Vectors:
+
+```idris
+infixr 5 ::
+
+data Vect : Nat -> Type -> Type where
+    Nil  : Vect Z a
+    (::) : a -> Vect k a -> Vect (S k) a
+
+app : Vect n a -> Vect m a -> Vect (n + m) a
+app Nil       ys = ys
+app (x :: xs) ys = x :: app xs ys
+```
+
+### LiquidHaskell
 
 ## Further reading
 
+* [Haskell Wiki - Language extensions](https://wiki.haskell.org/Language_extensions)
 * [24 Days of GHC Extensions](https://ocharles.org.uk/blog/pages/2014-12-01-24-days-of-ghc-extensions.html)

--- a/tutorials/12_exts-deptypes.md
+++ b/tutorials/12_exts-deptypes.md
@@ -204,7 +204,49 @@ app (x :: xs) ys = x :: app xs ys
 
 ### LiquidHaskell
 
+LiquidHaskell is a static verifier for Haskell, based on Liquid Types. It allows to annotate code with invariants that complement the invariants imposed by the types. These invariants are checked with an SMT solver. It is not about dependent types but [refinement types](https://en.wikipedia.org/wiki/Refinement_(computing)#Refinement_types) (you refine some defined type with rules not build it dependent from scratch).
+
+Visit: https://ucsd-progsys.github.io/liquidhaskell-blog/
+
+```haskell
+{--! run liquid with no-termination -}
+
+module SimpleRefinements where
+import Prelude hiding ((!!), length)
+import Language.Haskell.Liquid.Prelude
+
+
+-- |Simple Refinement Types
+
+{-@ zero :: {v:Int | v = 0} @-}
+zero     :: Int
+zero     =  0
+
+{-@ type Even = {v:Int | v mod 2 = 0} @-}
+
+{-@ zero'' :: Even @-}
+zero''     :: Int
+zero''     =  0
+
+-- |Lists
+
+infixr `C`
+data L a = N | C a (L a)
+
+{-@ natList :: L Nat @-}
+natList     :: L Int
+natList     =  0 `C` 1 `C` 3 `C` N
+
+{-@ evenList :: L Even @-}
+evenList     :: L Int
+evenList     =  0 `C` 2 `C` 8 `C` N
+```
+
 ## Further reading
 
 * [Haskell Wiki - Language extensions](https://wiki.haskell.org/Language_extensions)
 * [24 Days of GHC Extensions](https://ocharles.org.uk/blog/pages/2014-12-01-24-days-of-ghc-extensions.html)
+* [Agda](https://github.com/agda/agda)
+* [Idris](https://www.idris-lang.org)
+* [Idris - tutorial](http://docs.idris-lang.org/en/latest/tutorial/)
+* [LiquidHaskell](https://ucsd-progsys.github.io/liquidhaskell-blog/)

--- a/tutorials/12_exts-deptypes.md
+++ b/tutorials/12_exts-deptypes.md
@@ -6,7 +6,7 @@ Language extensions are used to enable language features in Haskell that may see
 
 ### TypeFamilies
 
-This extension allows use and definition of indexed type and data families to facilitate type-level programming. Indexed type families, or type families for short, are type constructors that represent sets of types. Set members are denoted by supplying the type family constructor with type parameters, which are called type indices. The difference between vanilla parametrised type constructors and family constructors is much like between parametrically polymorphic functions and (ad-hoc polymorphic) methods of type classes. Parametric polymorphic functions behave the same at all type instances, whereas class methods can change their behaviour in dependence on the class type parameters. Similarly, vanilla type constructors imply the same data representation for all type instances, but family constructors can have varying representation types for varying type indices. (see [GHC docs](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#type-families))
+This extension allows use and definition of indexed type and data families to facilitate type-level programming. Indexed type families, or type families for short, are type constructors that represent sets of types. Set members are denoted by supplying the type family constructor with type parameters, which are called type indices. The difference between vanilla parametrized type constructors and family constructors is much like between parametrically polymorphic functions and (ad-hoc polymorphic) methods of type classes. Parametric polymorphic functions behave the same in all type instances, whereas class methods can change their behavior in dependence on the class type parameters. Similarly, vanilla type constructors imply the same data representation for all type instances, but family constructors can have varying representation types for varying type indices. (see [GHC docs](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#type-families))
 
 ```haskell
 {-# LANGUAGE TypeFamilies #-}
@@ -33,7 +33,7 @@ instance XLength () where
 
 ### GADTs
 
-[Generalized algebraic data type](https://en.wikipedia.org/wiki/Generalized_algebraic_data_type) are a generalization of the algebraic data types that you are familiar with. Basically, they allow you to explicitly write down the types of the constructors. In this chapter, you'll learn why this is useful and how to declare your own. GADTs are mainly used to implement domain specific languages, and so this section will introduce them with a corresponding example.
+[Generalized algebraic data type](https://en.wikipedia.org/wiki/Generalized_algebraic_data_type) are a generalization of the algebraic data types that you are familiar with. Basically, they allow you to explicitly write down the types of the constructors. In this chapter, you'll learn why this is useful and how to declare your own. GADTs are mainly used to implement domain-specific languages, and so this section will introduce them with a corresponding example.
 
 ```haskell
 {-# LANGUAGE GADTs #-}
@@ -76,7 +76,7 @@ multiline = [r|<HTML>
 <PRE>|]
 ```
 
-You can of course write your own DSL or simplify syntax for yoursef. All you have to do is implement your [QuasiQuoter](http://hackage.haskell.org/package/template-haskell/docs/Language-Haskell-TH-Quote.html#t:QuasiQuoter) (part of Template Haskell). For example, you can create simple string-string map with semicolon and newlines:
+You can, of course, write your own DSL or simplify syntax for yourself. All you have to do is implement your [QuasiQuoter](http://hackage.haskell.org/package/template-haskell/docs/Language-Haskell-TH-Quote.html#t:QuasiQuoter) (part of Template Haskell). For example, you can create a simple string-string map with semicolon and newlines:
 
 ```haskell
 {-# LANGUAGE TemplateHaskell #-}
@@ -137,20 +137,20 @@ mymap1 = [mapBuilder|
          |]
 
 mymap2 :: [(String, Int)]
-mymap2 = map strstr2string [mapBuilder|
+mymap2 = map strstr2strint [mapBuilder|
            suchama4:1210
            perglr:1535
          |]
 
-strstr2string :: (String, String) -> (String, Int)
-strstr2string (x, y) = (x, read y)
+strstr2strint :: (String, String) -> (String, Int)
+strstr2strint (x, y) = (x, read y)
 ```
 
 Beautiful, right?!
 
 ### Template Haskell
 
-[Template Haskell](http://hackage.haskell.org/package/template-haskell) is a GHC extension to Haskell that adds compile-time metaprogramming facilities. The original design can be found here: http://research.microsoft.com/en-us/um/people/simonpj/papers/meta-haskell/. You could have seen part of it in action in the previous section about quasiquoting but it can do much more although quasiquotes are important part of it. Great explanation are [here](https://ocharles.org.uk/blog/guest-posts/2014-12-22-template-haskell.html) and [here](https://markkarpov.com/tutorial/th.html).
+[Template Haskell](http://hackage.haskell.org/package/template-haskell) is a GHC extension to Haskell that adds compile-time metaprogramming facilities. The original design can be found here: http://research.microsoft.com/en-us/um/people/simonpj/papers/meta-haskell/. You could have seen part of it in action in the previous section about quasiquoting but it can do much more although quasiquotes are an important part of it. Great explanation are [here](https://ocharles.org.uk/blog/guest-posts/2014-12-22-template-haskell.html) and [here](https://markkarpov.com/tutorial/th.html).
 
 ## Dependent and Refinement Types
 
@@ -164,7 +164,7 @@ Dependent types add complexity to a type system. Deciding the equality of depend
 
 ### Agda
 
-[Agda](http://wiki.portal.chalmers.se/agda/pmwiki.php) is a dependently typed functional programming language originally developed by Ulf Norell at Chalmers University of Technology with implementation described in his PhD thesis. But current version, Agda 2, is completely rewritten previous Agda from 1999.
+[Agda](http://wiki.portal.chalmers.se/agda/pmwiki.php) is a dependently typed functional programming language originally developed by Ulf Norell at Chalmers University of Technology with the implementation described in his PhD thesis. But current version, Agda 2, is completely rewritten in previous Agda from 1999.
 
 Visit https://github.com/agda/agda where are some examples as well!
 
@@ -177,7 +177,7 @@ Its features are influenced by Haskell and ML, and include:
 * Full dependent types with dependent pattern matching
 * Simple foreign function interface (to C)
 * Compiler-supported interactive editing: the compiler helps you write code using the types
-where clauses, with rule, simple case expressions, pattern matching let and lambda bindings
+where clauses, with a rule, simple case expressions, pattern matching let and lambda bindings
 * Dependent records with projection and update
 * Interfaces (similar to type classes in Haskell)
 * Type-driven overloading resolution
@@ -204,7 +204,7 @@ app (x :: xs) ys = x :: app xs ys
 
 ### LiquidHaskell
 
-LiquidHaskell is a static verifier for Haskell, based on Liquid Types. It allows to annotate code with invariants that complement the invariants imposed by the types. These invariants are checked with an SMT solver. It is not about dependent types but [refinement types](https://en.wikipedia.org/wiki/Refinement_(computing)#Refinement_types) (you refine some defined type with rules not build it dependent from scratch).
+LiquidHaskell is a static verifier for Haskell, based on Liquid Types. It allows annotating code with invariants that complement the invariants imposed by the types. These invariants are checked with an SMT solver. It is not about dependent types but [refinement types](https://en.wikipedia.org/wiki/Refinement_(computing)#Refinement_types) (you refine some defined type with rules not build it dependent from scratch).
 
 Visit: https://ucsd-progsys.github.io/liquidhaskell-blog/
 

--- a/tutorials/12_exts-deptypes.md
+++ b/tutorials/12_exts-deptypes.md
@@ -1,0 +1,27 @@
+# GHC Extensions and Dependent Types
+
+## GHC Language Extensions
+
+### TypeFamilies
+
+### RankNTypes
+
+### GADTs
+
+### DeriveGeneric
+
+### QuasiQuotes
+
+### Template Haskell
+
+## Dependent and Refinement Types
+
+### LiquidHaskell
+
+### Agda
+
+### Idris
+
+## Further reading
+
+* [24 Days of GHC Extensions](https://ocharles.org.uk/blog/pages/2014-12-01-24-days-of-ghc-extensions.html)


### PR DESCRIPTION
Final tutorial (initial version) about few GHC Extensions, Agda, Idris, and LiquidHaskell. It is kept very short because we should have discussion about term works... We can always go thru some Idris example :wink: if there is time for that.

Use squash merge when ready.